### PR TITLE
Update Helm chart to include diffsnap-controller

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/clusterrole-diffsnap.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-diffsnap.yaml
@@ -1,0 +1,24 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-diffsnap-controller-role
+  labels:
+    {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["differentialsnapshot.example.com"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["*"]
+  # Secret permission is optional.
+  # Enable it if your driver needs secret.
+  # For example, `csi.storage.k8s.io/snapshotter-secret-name` is set in VolumeSnapshotClass.
+  # See https://kubernetes-csi.github.io/docs/secrets-and-credentials.html for more details.
+  # - apiGroups: [ "" ]
+  #   resources: [ "secrets" ]
+  #   verbs: [ "get", "list" ]

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-diffsnap.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-diffsnap.yaml
@@ -1,0 +1,15 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-diffsnap-binding
+  labels:
+    {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.controller.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ebs-diffsnap-controller-role

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -58,16 +58,30 @@ spec:
         {{- $constraints | toYaml | nindent 8 }}
       {{- end }}
       {{- with .Values.controller.securityContext }}
-      securityContext:  
+      securityContext:
         {{- toYaml . | nindent 8 }}
-      {{- end }} 
+      {{- end }}
       containers:
+        - name: diffsnap-controller
+          args:
+          - -csi-address=$(ADDRESS)
+          command:
+          - /bin/diffsnap-controller
+          env:
+          - name: ADDRESS
+            value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+          image: {{ printf "%s:%s" .Values.sidecars.diffsnap.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.sidecars.diffsnap.image.tag | toString)) }}
+          imagePullPolicy: {{ .Values.sidecars.diffsnap.image.pullPolicy }}
+          volumeMounts:
+          - mountPath: /var/lib/csi/sockets/pluginproxy/
+            name: socket-dir
         - name: ebs-plugin
           image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             {{- if ne .Release.Name "kustomize" }}
-            - controller
+            # - controller
+            - all
             {{- else }}
             # - {all,controller,node} # specify the driver mode
             {{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -14,6 +14,11 @@ customLabels:
   # k8s-app: aws-ebs-csi-driver
 
 sidecars:
+  diffsnap:
+    image:
+      pullPolicy: Always
+      repository: ""
+      tag: ""
   provisioner:
     env: []
     image:


### PR DESCRIPTION
This PR adds the `diffsnap-controller` as a sidecar container to the Helm chart, so that it can be deployed alongside the EBS driver with:

```sh
helm upgrade --install aws-ebs-csi-driver \                                                
    --namespace kube-system \
    --set image.repository=<your_ebs_driver_image> \
    --set image.tag=<your_ebs_driver_image_tag> \
    --set sidecars.diffsnap.image.repository=<your_diffsnap_controller_image> \
    --set sidecars.diffsnap.image.tag=<your_diffsnap_controller_image_tag> \
    --set controller.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::<aws_account_id>:role/<iam_role_name> \
    ./charts/aws-ebs-csi-driver/
```

Note that the service account IAM annotation only works for EKS. For non-EKS cluster, the easiest thing to do is to configure the EC2 instance profile with the appropriate permissions. A sample IAM policy can be found [here](https://github.com/phuongatemc/diffsnapcontroller/blob/master/deploy/eks/iam-policy.json).