### PR TITLE
Convert CB blockIndex to offset to implement diffsnap api

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -139,8 +139,11 @@ func (d *differentialSnapshotService) GetChangedBlocks(ctx context.Context, req 
 	c := []*diffsnapcontroller.ChangedBlock{}
 	for _, cbt := range cbts {
 		for _, changedBlock := range cbt.ChangedBlocks {
+			// Convert blockIndex to offset
+			// DiffSnapController expects offset whereas, ebs returns blockIndex for blocks.
+			// Driver needs to do the conversion to implement the diffsnap common interface
 			c = append(c, &diffsnapcontroller.ChangedBlock{
-				Offset:  uint64(*changedBlock.BlockIndex),
+				Offset:  uint64(*changedBlock.BlockIndex) * uint64(*cbt.BlockSize),
 				Size:    uint64(*cbt.BlockSize),
 				ZeroOut: false,
 				Context: []byte{},


### PR DESCRIPTION
Signed-off-by: Prasad Ghangal <prasad.ghangal@gmail.com>

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

This PR adds logic to convert blockIndex to offset.
DiffSnapController expects offset whereas, ebs returns blockIndex for blocks. The driver needs to do the conversion to implement the diffsnap common interface


**What testing is done?** 
